### PR TITLE
fix(web): preserve link semantics in settings

### DIFF
--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -1,5 +1,6 @@
 import { Button as ButtonPrimitive } from "@base-ui/react/button";
 import { cva, type VariantProps } from "class-variance-authority";
+import type {ComponentProps} from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -55,4 +56,20 @@ function Button({
   );
 }
 
-export { Button, buttonVariants };
+/** Render navigation with link semantics and the shared button appearance. */
+function ButtonLink({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: ComponentProps<"a"> & VariantProps<typeof buttonVariants>) {
+  return (
+    <a
+      data-slot="button-link"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Button, ButtonLink, buttonVariants };

--- a/apps/web/src/review/review-project-picker.tsx
+++ b/apps/web/src/review/review-project-picker.tsx
@@ -9,7 +9,7 @@ import {type FormEvent, useMemo, useState} from "react";
 
 import {type Project} from "@/api/client";
 import {Alert, AlertDescription} from "@/components/ui/alert";
-import {Button} from "@/components/ui/button";
+import {Button, ButtonLink} from "@/components/ui/button";
 import {
   Field,
   FieldError,
@@ -142,24 +142,24 @@ export function ReviewProjectPicker({
                   <Separator />
                   <div className="as-project-actions">
                     {selectedProject === null ? null : (
-                      <Button
+                      <ButtonLink
+                        href={projectSettingsHref(selectedProject.id)}
                         onClick={() => setPickerOpen(false)}
-                        render={<a href={projectSettingsHref(selectedProject.id)} />}
                         size="sm"
                         variant="ghost"
                       >
                         <HugeiconsIcon data-icon="inline-start" icon={Settings02Icon} strokeWidth={2} />
                         Project settings
-                      </Button>
+                      </ButtonLink>
                     )}
-                    <Button
+                    <ButtonLink
+                      href="/review/settings/projects"
                       onClick={() => setPickerOpen(false)}
-                      render={<a href="/review/settings/projects" />}
                       size="sm"
                       variant="ghost"
                     >
                       Manage projects
-                    </Button>
+                    </ButtonLink>
                     <Button onClick={showCreateForm} size="sm" type="button" variant="ghost">
                       <HugeiconsIcon data-icon="inline-start" icon={Add01Icon} strokeWidth={2} />
                       New project

--- a/apps/web/src/review/review-settings.tsx
+++ b/apps/web/src/review/review-settings.tsx
@@ -3,7 +3,7 @@ import {HugeiconsIcon} from "@hugeicons/react";
 
 import {api, type Project, type Session} from "@/api/client";
 import {StatePanel} from "@/components/product";
-import {Button} from "@/components/ui/button";
+import {Button, ButtonLink} from "@/components/ui/button";
 import {ArtifactMark} from "./artifact-mark.tsx";
 import {parseSettingsRoute, type SettingsRoute} from "./review-routes.ts";
 import {ApiKeysScreen} from "./settings-api-keys.tsx";
@@ -56,10 +56,10 @@ export function ReviewSettings({
             >
               <HugeiconsIcon icon={theme === "moon" ? Sun03Icon : Moon02Icon} strokeWidth={1.8} />
             </button>
-            <Button render={<a href={reviewHref} />} size="sm" variant="outline">
+            <ButtonLink href={reviewHref} size="sm" variant="outline">
               <HugeiconsIcon data-icon="inline-start" icon={ArrowLeft01Icon} strokeWidth={1.8} />
               Back to Review
-            </Button>
+            </ButtonLink>
             <Button
               onClick={() => void api.logout().finally(() => window.location.assign("/review"))}
               size="sm"
@@ -120,7 +120,11 @@ function SettingsContent({
   if (route.kind === "notFound") {
     return (
       <StatePanel
-        action={<Button render={<a href="/review/settings/projects" />} variant="outline">View settings</Button>}
+        action={(
+          <ButtonLink href="/review/settings/projects" variant="outline">
+            View settings
+          </ButtonLink>
+        )}
         description="This Artifact Server settings route does not exist."
         title="Page not found"
       />

--- a/apps/web/src/review/settings-projects.tsx
+++ b/apps/web/src/review/settings-projects.tsx
@@ -8,7 +8,7 @@ import {
   type ProjectGitHistorySetting,
 } from "@/api/client";
 import {ErrorPanel, PageHeader, StatePanel, StatusBadge} from "@/components/product";
-import {Button} from "@/components/ui/button";
+import {Button, ButtonLink} from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -149,16 +149,16 @@ export function SettingsProjects({
                   </td>
                   <td className="px-4 py-4">
                     <div className="flex justify-end gap-2">
-                      <Button
-                        render={<a href={`/review?project=${encodeURIComponent(project.id)}`} />}
+                      <ButtonLink
+                        href={`/review?project=${encodeURIComponent(project.id)}`}
                         size="sm"
                         variant="outline"
                       >
                         Open artifacts
-                      </Button>
-                      <Button render={<a href={projectSettingsHref(project.id)} />} size="sm">
+                      </ButtonLink>
+                      <ButtonLink href={projectSettingsHref(project.id)} size="sm">
                         Settings
-                      </Button>
+                      </ButtonLink>
                     </div>
                   </td>
                 </tr>
@@ -217,7 +217,11 @@ export function SettingsProject({
   if (project === null) {
     return (
       <StatePanel
-        action={<Button render={<a href="/review/settings/projects" />} variant="outline">View projects</Button>}
+        action={(
+          <ButtonLink href="/review/settings/projects" variant="outline">
+            View projects
+          </ButtonLink>
+        )}
         description="The project named by this settings URL is unavailable."
         title="Project not found"
       />
@@ -282,9 +286,12 @@ export function SettingsProject({
     <div className="flex flex-col gap-8">
       <PageHeader
         actions={(
-          <Button render={<a href={`/review?project=${encodeURIComponent(project.id)}`} />} variant="outline">
+          <ButtonLink
+            href={`/review?project=${encodeURIComponent(project.id)}`}
+            variant="outline"
+          >
             Open artifacts
-          </Button>
+          </ButtonLink>
         )}
         description={project.archivedAt === null
           ? "Manage this project's name, lifecycle, and optional history."

--- a/apps/web/src/review/settings-public-links.tsx
+++ b/apps/web/src/review/settings-public-links.tsx
@@ -13,7 +13,7 @@ import {
   AlertDescription,
   AlertTitle,
 } from "@/components/ui/alert";
-import {Button} from "@/components/ui/button";
+import {Button, ButtonLink} from "@/components/ui/button";
 import {Checkbox} from "@/components/ui/checkbox";
 import {
   Dialog,
@@ -459,13 +459,15 @@ export function PublicLinksScreen() {
                         </td>
                         <td className="px-4 py-4 align-top">
                           <div className="flex justify-end gap-2">
-                            <Button
-                              render={<a href={item.links.public} rel="noreferrer" target="_blank" />}
+                            <ButtonLink
+                              href={item.links.public}
+                              rel="noreferrer"
                               size="xs"
+                              target="_blank"
                               variant="outline"
                             >
                               Open
-                            </Button>
+                            </ButtonLink>
                             <Button
                               disabled={pending}
                               onClick={() => setConfirmation([item])}


### PR DESCRIPTION
## Summary
- render settings navigation as native anchors with shared button styling
- remove Base UI button semantics from project picker and settings links
- preserve existing appearance and behavior

## Verification
- `pnpm verify:iteration`
- browser suite: 25/25 passed