### PR TITLE
ci: add tagged release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,13 @@
 name: CI
 
 on:
+  workflow_call:
+    inputs:
+      tier:
+        description: Gate tier to run from a calling workflow
+        required: false
+        default: release
+        type: string
   pull_request:
     branches: [main]
   merge_group:
@@ -24,13 +31,13 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.event.pull_request.number || github.ref }}
+  group: ci-${{ inputs.tier }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   build:
     name: PR / Build and static policy
-    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.tier == 'pr')
+    if: inputs.tier != 'release' && (github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.tier == 'pr'))
     runs-on: ubuntu-latest
     timeout-minutes: 8
     steps:
@@ -189,6 +196,7 @@ jobs:
 
   portable:
     name: macOS portability
+    if: inputs.tier != 'release'
     runs-on: macos-14
     timeout-minutes: 12
     steps:
@@ -216,7 +224,7 @@ jobs:
 
   full:
     name: Full / Linux iteration gate
-    if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.tier == 'full')
+    if: inputs.tier == 'release' || (github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.tier == 'full'))
     runs-on: ubuntu-latest
     timeout-minutes: 47
     env:
@@ -239,7 +247,14 @@ jobs:
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 10.34.3
-      - name: Install Node.js
+      - name: Install Node.js without a release cache
+        if: inputs.tier == 'release'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.15.0
+          package-manager-cache: false
+      - name: Install Node.js with the pnpm cache
+        if: inputs.tier != 'release'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24.15.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,441 @@
+name: Tagged Release
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/ci.yml
+      - .github/workflows/release.yml
+      - scripts/assemble-release-assets.mjs
+      - scripts/build-oci-image.sh
+      - scripts/check-release-ref.mjs
+      - scripts/check-release-version.mjs
+      - scripts/extract-oci-sboms.mjs
+      - scripts/generate-release-sboms.sh
+      - scripts/install-release-syft.sh
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Build and verify without publishing
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    name: Verify release reference
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      publish: ${{ steps.metadata.outputs.publish }}
+      revision: ${{ steps.metadata.outputs.revision }}
+      series: ${{ steps.metadata.outputs.series }}
+      tag: ${{ steps.metadata.outputs.tag }}
+      version: ${{ steps.metadata.outputs.version }}
+    steps:
+      - name: Checkout complete repository history
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: 10.34.3
+      - name: Install Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.15.0
+          package-manager-cache: false
+      - name: Install dependencies without a cache
+        run: pnpm install --frozen-lockfile
+      - name: Verify release metadata and ref
+        id: metadata
+        env:
+          ARTIFACTSERVER_EVENT_NAME: ${{ github.event_name }}
+          ARTIFACTSERVER_REF_NAME: ${{ github.ref_name }}
+          ARTIFACTSERVER_REF_TYPE: ${{ github.ref_type }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          version=$(node -p "JSON.parse(require('node:fs').readFileSync('package.json', 'utf8')).version")
+          revision=$(git rev-parse HEAD)
+          series=${version%.*}
+          tag="v$version"
+          publish=false
+          if [[ "$ARTIFACTSERVER_EVENT_NAME" == push && "$ARTIFACTSERVER_REF_TYPE" == tag ]]; then
+            tag="$ARTIFACTSERVER_REF_NAME"
+            publish=true
+            git fetch --force --no-tags origin main:refs/remotes/origin/main
+            node scripts/check-release-version.mjs --tag "$tag"
+            node scripts/check-release-ref.mjs --tag "$tag" --main-ref origin/main
+          else
+            node scripts/check-release-version.mjs
+            node scripts/check-release-ref.mjs --dry-run
+          fi
+          {
+            printf 'publish=%s\n' "$publish"
+            printf 'revision=%s\n' "$revision"
+            printf 'series=%s\n' "$series"
+            printf 'tag=%s\n' "$tag"
+            printf 'version=%s\n' "$version"
+          } >> "$GITHUB_OUTPUT"
+
+  gate:
+    name: Canonical release gate
+    needs: verify
+    uses: ./.github/workflows/ci.yml
+    with:
+      tier: release
+
+  packages:
+    name: Build Node and adapter packages
+    needs: [verify, gate]
+    runs-on: ubuntu-latest
+    timeout-minutes: 18
+    steps:
+      - name: Checkout release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: 10.34.3
+      - name: Install Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.15.0
+          package-manager-cache: false
+      - name: Install dependencies without a cache
+        run: pnpm install --frozen-lockfile
+      - name: Build portable local package
+        env:
+          ARTIFACTSERVER_OUTPUT: ${{ github.workspace }}/release/package-bundle
+        run: pnpm package:local "$ARTIFACTSERVER_OUTPUT"
+      - name: Pack public adapters
+        env:
+          ARTIFACTSERVER_OUTPUT: ${{ github.workspace }}/release/package-bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          pnpm --dir integrations/pi pack --pack-destination "$ARTIFACTSERVER_OUTPUT"
+          pnpm --dir integrations/opencode pack --pack-destination "$ARTIFACTSERVER_OUTPUT"
+          pnpm --dir integrations/claude-channel pack --pack-destination "$ARTIFACTSERVER_OUTPUT"
+      - name: Install verified Syft
+        run: scripts/install-release-syft.sh "$RUNNER_TEMP/syft"
+      - name: Generate package SPDX SBOMs
+        env:
+          ARTIFACTSERVER_VERSION: ${{ needs.verify.outputs.version }}
+        run: >-
+          scripts/generate-release-sboms.sh
+          "$RUNNER_TEMP/syft/syft"
+          release/package-bundle
+          release/package-bundle
+          "$ARTIFACTSERVER_VERSION"
+          packages
+      - name: Upload package release inputs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-packages-${{ github.run_id }}-${{ github.run_attempt }}
+          path: release/package-bundle/
+          if-no-files-found: error
+          retention-days: 7
+
+  image:
+    name: Build and optionally publish OCI image
+    needs: [verify, gate]
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: 10.34.3
+      - name: Install Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.15.0
+          package-manager-cache: false
+      - name: Install dependencies without a cache
+        run: pnpm install --frozen-lockfile
+      - name: Prepare attestation-capable BuildKit
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker buildx create \
+            --driver docker-container \
+            --driver-opt image=moby/buildkit@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8 \
+            --name artifact-server-release \
+            --use
+          docker buildx inspect --bootstrap
+      - name: Sign in to GHCR for a tagged release
+        if: needs.verify.outputs.publish == 'true'
+        env:
+          ARTIFACTSERVER_GITHUB_ACTOR: ${{ github.actor }}
+          ARTIFACTSERVER_GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          docker login ghcr.io
+          --username "$ARTIFACTSERVER_GITHUB_ACTOR"
+          --password-stdin
+          <<< "$ARTIFACTSERVER_GITHUB_TOKEN"
+      - name: Build release image
+        env:
+          ARTIFACTSERVER_IMAGE_PUSH: ${{ needs.verify.outputs.publish }}
+          ARTIFACTSERVER_IMAGE_TAGS: ghcr.io/plannotator/artifact-server:${{ needs.verify.outputs.tag }},ghcr.io/plannotator/artifact-server:${{ needs.verify.outputs.series }}
+        run: pnpm package:oci release/image-work
+      - name: Extract verified image SPDX SBOMs
+        env:
+          ARTIFACTSERVER_VERSION: ${{ needs.verify.outputs.version }}
+        run: >-
+          scripts/generate-release-sboms.sh
+          unused
+          release/image-work
+          release/image-bundle
+          "$ARTIFACTSERVER_VERSION"
+          image
+      - name: Record immutable image reference
+        env:
+          ARTIFACTSERVER_VERSION: ${{ needs.verify.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          manifest="release/image-work/artifact-server-$ARTIFACTSERVER_VERSION.oci.tar.manifest.json"
+          digest=$(jq --exit-status --raw-output '.imageIndexDigest' "$manifest")
+          mkdir -p release/image-bundle
+          cp -- "$manifest" \
+            "release/image-bundle/artifact-server-$ARTIFACTSERVER_VERSION-oci.manifest.json"
+          printf '%s\n' "ghcr.io/plannotator/artifact-server@$digest" \
+            > release/image-bundle/image-reference.txt
+      - name: Verify published image tags resolve to the built digest
+        if: needs.verify.outputs.publish == 'true'
+        env:
+          ARTIFACTSERVER_TAG: ${{ needs.verify.outputs.tag }}
+          ARTIFACTSERVER_SERIES: ${{ needs.verify.outputs.series }}
+          ARTIFACTSERVER_VERSION: ${{ needs.verify.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected=$(jq --exit-status --raw-output \
+            '.imageIndexDigest' \
+            "release/image-bundle/artifact-server-$ARTIFACTSERVER_VERSION-oci.manifest.json")
+          for tag in "$ARTIFACTSERVER_TAG" "$ARTIFACTSERVER_SERIES"; do
+            actual="sha256:$(docker buildx imagetools inspect --raw \
+              "ghcr.io/plannotator/artifact-server:$tag" | sha256sum | cut -d ' ' -f 1)"
+            if [[ "$actual" != "$expected" ]]; then
+              printf 'Published tag %s resolved to %s, expected %s.\n' \
+                "$tag" "$actual" "$expected" >&2
+              exit 1
+            fi
+          done
+      - name: Upload image release inputs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-image-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            release/image-work/artifact-server-${{ needs.verify.outputs.version }}.oci.tar
+            release/image-bundle/
+          if-no-files-found: error
+          retention-days: 7
+
+  assemble:
+    name: Assemble downloadable release assets
+    needs: [verify, packages, image]
+    runs-on: ubuntu-latest
+    timeout-minutes: 6
+    steps:
+      - name: Checkout release tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Download package release inputs
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-packages-${{ github.run_id }}-${{ github.run_attempt }}
+          path: release/incoming/packages
+      - name: Download image release inputs
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-image-${{ github.run_id }}-${{ github.run_attempt }}
+          path: release/incoming/image
+      - name: Assemble assets and checksums
+        env:
+          ARTIFACTSERVER_VERSION: ${{ needs.verify.outputs.version }}
+        run: >-
+          node scripts/assemble-release-assets.mjs
+          release/incoming
+          release/public
+          "$ARTIFACTSERVER_VERSION"
+      - name: Verify every downloadable asset checksum
+        working-directory: release/public
+        run: sha256sum --check --strict SHA256SUMS
+      - name: Upload downloadable release assets
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-public-${{ github.run_id }}-${{ github.run_attempt }}
+          path: release/public/
+          if-no-files-found: error
+          retention-days: 14
+
+  attest:
+    name: Attest release assets
+    if: needs.verify.outputs.publish == 'true'
+    needs: [verify, assemble]
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+      packages: write
+    steps:
+      - name: Download downloadable release assets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-public-${{ github.run_id }}-${{ github.run_attempt }}
+          path: release/public
+      - name: Read immutable image subject
+        id: image
+        env:
+          ARTIFACTSERVER_VERSION: ${{ needs.verify.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          reference=$(cat release/public/image-reference.txt)
+          digest=${reference##*@}
+          printf 'digest=%s\n' "$digest" >> "$GITHUB_OUTPUT"
+          printf 'name=%s\n' "${reference%@*}" >> "$GITHUB_OUTPUT"
+      - name: Attest downloadable asset provenance
+        uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3.0.0
+        with:
+          subject-path: release/public/*
+      - name: Attest local package SBOM
+        uses: actions/attest-sbom@51e74621a501c89df81fc1391c5a8f4cfc9fab2f # v3.0.0
+        with:
+          subject-path: release/public/artifact-server-${{ needs.verify.outputs.version }}-node.tar.gz
+          sbom-path: release/public/artifact-server-${{ needs.verify.outputs.version }}-node.spdx.json
+      - name: Attest Pi adapter SBOM
+        uses: actions/attest-sbom@51e74621a501c89df81fc1391c5a8f4cfc9fab2f # v3.0.0
+        with:
+          subject-path: release/public/plannotator-artifact-server-pi-${{ needs.verify.outputs.version }}.tgz
+          sbom-path: release/public/plannotator-artifact-server-pi-${{ needs.verify.outputs.version }}.spdx.json
+      - name: Attest OpenCode adapter SBOM
+        uses: actions/attest-sbom@51e74621a501c89df81fc1391c5a8f4cfc9fab2f # v3.0.0
+        with:
+          subject-path: release/public/plannotator-artifact-server-opencode-${{ needs.verify.outputs.version }}.tgz
+          sbom-path: release/public/plannotator-artifact-server-opencode-${{ needs.verify.outputs.version }}.spdx.json
+      - name: Attest Claude channel SBOM
+        uses: actions/attest-sbom@51e74621a501c89df81fc1391c5a8f4cfc9fab2f # v3.0.0
+        with:
+          subject-path: release/public/plannotator-artifact-server-claude-channel-${{ needs.verify.outputs.version }}.tgz
+          sbom-path: release/public/plannotator-artifact-server-claude-channel-${{ needs.verify.outputs.version }}.spdx.json
+      - name: Attest image provenance in GHCR
+        uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3.0.0
+        with:
+          subject-name: ${{ steps.image.outputs.name }}
+          subject-digest: ${{ steps.image.outputs.digest }}
+          push-to-registry: true
+      - name: Attest image SBOM in GHCR
+        uses: actions/attest-sbom@51e74621a501c89df81fc1391c5a8f4cfc9fab2f # v3.0.0
+        with:
+          subject-name: ${{ steps.image.outputs.name }}
+          subject-digest: ${{ steps.image.outputs.digest }}
+          sbom-path: release/public/artifact-server-${{ needs.verify.outputs.version }}-oci-linux-amd64.spdx.json
+          push-to-registry: true
+      - name: Attest arm64 image SBOM in GHCR
+        uses: actions/attest-sbom@51e74621a501c89df81fc1391c5a8f4cfc9fab2f # v3.0.0
+        with:
+          subject-name: ${{ steps.image.outputs.name }}
+          subject-digest: ${{ steps.image.outputs.digest }}
+          sbom-path: release/public/artifact-server-${{ needs.verify.outputs.version }}-oci-linux-arm64.spdx.json
+          push-to-registry: true
+
+  publish-npm:
+    name: Publish public npm adapters
+    if: needs.verify.outputs.publish == 'true'
+    needs: [verify, assemble, attest]
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Install Node.js for npm provenance
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.15.0
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - name: Download downloadable release assets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-public-${{ github.run_id }}-${{ github.run_attempt }}
+          path: release/public
+      - name: Publish adapters
+        env:
+          ARTIFACTSERVER_REPOSITORY_VISIBILITY: ${{ github.event.repository.visibility }}
+          ARTIFACTSERVER_VERSION: ${{ needs.verify.outputs.version }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          provenance_args=()
+          if [[ "$ARTIFACTSERVER_REPOSITORY_VISIBILITY" == public ]]; then
+            provenance_args+=(--provenance)
+          else
+            printf '%s\n' \
+              '::notice::npm provenance is deferred until the source repository is public.'
+          fi
+          npm publish \
+            "release/public/plannotator-artifact-server-pi-$ARTIFACTSERVER_VERSION.tgz" \
+            "${provenance_args[@]}" --access public
+          npm publish \
+            "release/public/plannotator-artifact-server-opencode-$ARTIFACTSERVER_VERSION.tgz" \
+            "${provenance_args[@]}" --access public
+          npm publish \
+            "release/public/plannotator-artifact-server-claude-channel-$ARTIFACTSERVER_VERSION.tgz" \
+            "${provenance_args[@]}" --access public
+
+  release:
+    name: Create GitHub prerelease
+    if: needs.verify.outputs.publish == 'true'
+    needs: [verify, assemble, attest, publish-npm]
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    permissions:
+      contents: write
+    steps:
+      - name: Download downloadable release assets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-public-${{ github.run_id }}-${{ github.run_attempt }}
+          path: release/public
+      - name: Create verified GitHub prerelease
+        env:
+          ARTIFACTSERVER_TAG: ${{ needs.verify.outputs.tag }}
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create "$ARTIFACTSERVER_TAG"
+          release/public/*
+          --repo "$GITHUB_REPOSITORY"
+          --verify-tag
+          --prerelease
+          --generate-notes
+          --title "Artifact Server $ARTIFACTSERVER_TAG"

--- a/scripts/assemble-release-assets.mjs
+++ b/scripts/assemble-release-assets.mjs
@@ -1,0 +1,95 @@
+import {createHash} from "node:crypto";
+import {createReadStream} from "node:fs";
+import {copyFile, mkdir, readFile, readdir, writeFile} from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+const [inputDirectory, outputDirectory, version] = process.argv.slice(2);
+if (inputDirectory === undefined || outputDirectory === undefined || version === undefined) {
+  throw new Error(
+    "Usage: assemble-release-assets.mjs <input-directory> <output-directory> <version>.",
+  );
+}
+
+const expectedFiles = [
+  `artifact-server-${version}-node.tar.gz`,
+  `artifact-server-${version}-node.tar.gz.manifest.json`,
+  `artifact-server-${version}-node.spdx.json`,
+  `artifact-server-${version}-oci.manifest.json`,
+  `artifact-server-${version}-oci-linux-amd64.spdx.json`,
+  `artifact-server-${version}-oci-linux-arm64.spdx.json`,
+  "image-reference.txt",
+  `plannotator-artifact-server-claude-channel-${version}.spdx.json`,
+  `plannotator-artifact-server-claude-channel-${version}.tgz`,
+  `plannotator-artifact-server-opencode-${version}.spdx.json`,
+  `plannotator-artifact-server-opencode-${version}.tgz`,
+  `plannotator-artifact-server-pi-${version}.spdx.json`,
+  `plannotator-artifact-server-pi-${version}.tgz`,
+];
+
+await mkdir(outputDirectory, {recursive: true});
+const discoveredFiles = await findFiles(inputDirectory);
+const copyOperations = expectedFiles.map((expectedFile) => {
+  const candidates = discoveredFiles.filter((candidate) =>
+    path.basename(candidate) === expectedFile
+  );
+  if (candidates.length !== 1) {
+    throw new Error(
+      `Expected one ${expectedFile} input, found ${candidates.length}.`,
+    );
+  }
+  return copyFile(candidates[0], path.join(outputDirectory, expectedFile));
+});
+await Promise.all(copyOperations);
+
+const unexpectedPublicFiles = (await readdir(outputDirectory))
+  .filter((file) => file !== "SHA256SUMS" && !expectedFiles.includes(file));
+if (unexpectedPublicFiles.length > 0) {
+  throw new Error(
+    `Release output contains unexpected files: ${unexpectedPublicFiles.join(", ")}.`,
+  );
+}
+
+const checksumLines = await Promise.all(
+  expectedFiles.toSorted((left, right) => left.localeCompare(right)).map(
+    async (file) => `${await sha256(path.join(outputDirectory, file))}  ${file}`,
+  ),
+);
+await writeFile(
+  path.join(outputDirectory, "SHA256SUMS"),
+  `${checksumLines.join("\n")}\n`,
+);
+
+const imageReference = await readFile(
+  path.join(outputDirectory, "image-reference.txt"),
+  "utf8",
+);
+if (!imageReference.includes(`ghcr.io/plannotator/artifact-server@sha256:`)) {
+  throw new Error("The image reference does not contain the immutable GHCR digest.");
+}
+
+process.stdout.write(
+  `Assembled ${expectedFiles.length} release assets plus SHA256SUMS.\n`,
+);
+
+async function findFiles(directory) {
+  const entries = await readdir(directory, {withFileTypes: true});
+  const nestedFiles = await Promise.all(entries.map(async (entry) => {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      return findFiles(entryPath);
+    }
+    return entry.isFile() ? [entryPath] : [];
+  }));
+  return nestedFiles.flat();
+}
+
+function sha256(filePath) {
+  return new Promise((resolve, reject) => {
+    const hash = createHash("sha256");
+    const stream = createReadStream(filePath);
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.once("error", reject);
+    stream.once("end", () => resolve(hash.digest("hex")));
+  });
+}

--- a/scripts/build-oci-image.sh
+++ b/scripts/build-oci-image.sh
@@ -10,6 +10,8 @@ artifactserver_revision=$(git -C "$artifactserver_repository" rev-parse HEAD)
 artifactserver_created=$(git -C "$artifactserver_repository" show -s --format=%cI HEAD)
 artifactserver_source=${ARTIFACT_SERVER_IMAGE_SOURCE:-}
 artifactserver_image_tag=${ARTIFACT_SERVER_IMAGE_TAG:-"ghcr.io/plannotator/artifact-server:$artifactserver_version"}
+artifactserver_image_tags=${ARTIFACT_SERVER_IMAGE_TAGS:-$artifactserver_image_tag}
+artifactserver_push=${ARTIFACT_SERVER_IMAGE_PUSH:-false}
 artifactserver_sbom_scanner="docker.io/docker/buildkit-syft-scanner:stable-1@sha256:79e7b013cbec16bbb436f312819a49a4a57752b2270c1a9332ae1a10fcc82a68"
 artifactserver_source_tree_clean=true
 if [[ -n "$(git -C "$artifactserver_repository" status --porcelain --untracked-files=normal)" ]]; then
@@ -36,6 +38,31 @@ trap cleanup EXIT
 
 mkdir -p -- "$artifactserver_output" "$artifactserver_layout"
 
+IFS=',' read -r -a artifactserver_tags <<< "$artifactserver_image_tags"
+artifactserver_tag_arguments=()
+for artifactserver_tag in "${artifactserver_tags[@]}"; do
+  if [[ -z "$artifactserver_tag" || "$artifactserver_tag" =~ [[:space:]] ]]; then
+    printf 'Invalid OCI image tag: %q\n' "$artifactserver_tag" >&2
+    exit 1
+  fi
+  artifactserver_tag_arguments+=(--tag "$artifactserver_tag")
+done
+
+artifactserver_output_arguments=(
+  --output "type=oci,dest=$artifactserver_staged_archive"
+)
+case "$artifactserver_push" in
+  true)
+    artifactserver_output_arguments+=(--output type=registry)
+    ;;
+  false)
+    ;;
+  *)
+    printf 'ARTIFACT_SERVER_IMAGE_PUSH must be true or false.\n' >&2
+    exit 1
+    ;;
+esac
+
 docker buildx build \
   --file "$artifactserver_repository/packaging/oci/Dockerfile" \
   --platform linux/amd64,linux/arm64 \
@@ -47,8 +74,8 @@ docker buildx build \
   --build-arg "SOURCE_DATE_EPOCH=$(git -C "$artifactserver_repository" show -s --format=%ct HEAD)" \
   --provenance=mode=max \
   --attest "type=sbom,generator=$artifactserver_sbom_scanner" \
-  --tag "$artifactserver_image_tag" \
-  --output "type=oci,dest=$artifactserver_staged_archive" \
+  "${artifactserver_tag_arguments[@]}" \
+  "${artifactserver_output_arguments[@]}" \
   "$artifactserver_repository"
 
 tar -xf "$artifactserver_staged_archive" -C "$artifactserver_layout"

--- a/scripts/check-release-ref.mjs
+++ b/scripts/check-release-ref.mjs
@@ -1,0 +1,78 @@
+import {execFileSync} from "node:child_process";
+import {readFile} from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import {fileURLToPath} from "node:url";
+
+import {z} from "zod";
+
+const repositoryRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+function fail(message) {
+  throw new Error(`Release reference check failed: ${message}`);
+}
+
+function git(...arguments_) {
+  return execFileSync("git", arguments_, {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+  }).trim();
+}
+
+function argumentValue(name) {
+  const index = process.argv.indexOf(name);
+  if (index === -1) return null;
+  const value = process.argv[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    fail(`${name} requires a value.`);
+  }
+  return value;
+}
+
+const dryRun = process.argv.includes("--dry-run");
+const tag = argumentValue("--tag");
+const mainReference = argumentValue("--main-ref") ?? "origin/main";
+const expectedArguments = new Set([
+  "--dry-run",
+  "--tag",
+  "--main-ref",
+  tag,
+  mainReference,
+]);
+for (const argument of process.argv.slice(2)) {
+  if (!expectedArguments.has(argument)) fail(`unknown argument ${argument}.`);
+}
+if (dryRun === (tag !== null)) {
+  fail("choose exactly one of --dry-run or --tag vX.Y.Z.");
+}
+
+const packageMetadata = z.object({version: z.string().min(1)}).parse(JSON.parse(
+  await readFile(path.join(repositoryRoot, "package.json"), "utf8"),
+));
+const expectedTag = `v${packageMetadata.version}`;
+
+if (dryRun) {
+  process.stdout.write(`${git("rev-parse", "HEAD")}\n`);
+  process.stdout.write(`Dry run uses the v${packageMetadata.version} release contract.\n`);
+} else {
+  if (tag !== expectedTag) {
+    fail(`tag ${tag} does not match package version ${packageMetadata.version}.`);
+  }
+  if (git("cat-file", "-t", tag) !== "tag") {
+    fail(`${tag} is not an annotated tag.`);
+  }
+
+  const taggedCommit = git("rev-parse", `${tag}^{commit}`);
+  const firstParentCommits = new Set(
+    git("rev-list", "--first-parent", mainReference).split("\n"),
+  );
+  if (!firstParentCommits.has(taggedCommit)) {
+    fail(`${tag} does not belong to ${mainReference}'s first-parent history.`);
+  }
+
+  process.stdout.write(`${taggedCommit}\n`);
+  process.stdout.write(`${tag} is annotated and belongs to ${mainReference}.\n`);
+}

--- a/scripts/extract-oci-sboms.mjs
+++ b/scripts/extract-oci-sboms.mjs
@@ -1,0 +1,113 @@
+import {createHash} from "node:crypto";
+import {readFile, writeFile} from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+import {z} from "zod";
+
+const [layoutDirectory, outputDirectory, version] = process.argv.slice(2);
+if (layoutDirectory === undefined || outputDirectory === undefined || version === undefined) {
+  throw new Error(
+    "Usage: extract-oci-sboms.mjs <layout-directory> <output-directory> <version>.",
+  );
+}
+
+const digestSchema = z.string().regex(/^sha256:[a-f0-9]{64}$/u);
+const descriptorSchema = z.object({
+  annotations: z.record(z.string(), z.string()).optional(),
+  digest: digestSchema,
+  mediaType: z.string().min(1),
+  platform: z.object({
+    architecture: z.string().min(1),
+    os: z.string().min(1),
+  }).optional(),
+});
+const indexSchema = z.object({manifests: z.array(descriptorSchema)});
+const attestationManifestSchema = z.object({
+  layers: z.array(z.object({
+    annotations: z.record(z.string(), z.string()),
+    digest: digestSchema,
+  })),
+});
+const statementSchema = z.object({
+  predicate: z.record(z.string(), z.unknown()),
+  predicateType: z.literal("https://spdx.dev/Document"),
+});
+
+const layoutIndex = indexSchema.parse(JSON.parse(
+  await readFile(path.join(layoutDirectory, "index.json"), "utf8"),
+));
+const rootDigests = new Set(layoutIndex.manifests
+  .filter((descriptor) =>
+    descriptor.mediaType === "application/vnd.oci.image.index.v1+json"
+  )
+  .map((descriptor) => descriptor.digest));
+if (rootDigests.size !== 1) {
+  throw new Error(`Expected one release image index, found ${rootDigests.size}.`);
+}
+const [rootDigest] = rootDigests;
+if (rootDigest === undefined) throw new Error("The release image index is missing.");
+const imageIndex = indexSchema.parse(await readJsonBlob(rootDigest));
+const platformByManifest = new Map(imageIndex.manifests.flatMap((descriptor) => {
+  const platform = descriptor.platform;
+  if (platform === undefined || platform.os === "unknown") return [];
+  return [[descriptor.digest, `${platform.os}-${platform.architecture}`]];
+}));
+
+const writtenPlatforms = (await Promise.all(imageIndex.manifests.map(
+  async (descriptor) => {
+    const referencedManifest = descriptor.annotations?.["vnd.docker.reference.digest"];
+    if (referencedManifest === undefined) return null;
+    const platform = platformByManifest.get(referencedManifest);
+    if (platform === undefined) {
+      throw new Error(
+        `Attestation ${descriptor.digest} references an unknown image manifest.`,
+      );
+    }
+    const attestationManifest = attestationManifestSchema.parse(
+      await readJsonBlob(descriptor.digest),
+    );
+    const spdxLayers = attestationManifest.layers.filter((layer) =>
+      layer.annotations["in-toto.io/predicate-type"] === "https://spdx.dev/Document"
+    );
+    if (spdxLayers.length !== 1) {
+      throw new Error(
+        `Expected one SPDX statement for ${platform}, found ${spdxLayers.length}.`,
+      );
+    }
+    const statement = statementSchema.parse(await readJsonBlob(spdxLayers[0].digest));
+    if (statement.predicate["spdxVersion"] !== "SPDX-2.3") {
+      throw new Error(`The ${platform} image SBOM is not SPDX 2.3.`);
+    }
+    await writeFile(
+      path.join(
+        outputDirectory,
+        `artifact-server-${version}-oci-${platform}.spdx.json`,
+      ),
+      `${JSON.stringify(statement.predicate, null, 2)}\n`,
+    );
+    return platform;
+  },
+))).filter((platform) => platform !== null)
+  .toSorted((left, right) => left.localeCompare(right));
+
+const expectedPlatforms = ["linux-amd64", "linux-arm64"];
+if (JSON.stringify(writtenPlatforms) !== JSON.stringify(expectedPlatforms)) {
+  throw new Error(
+    `Expected image SBOMs for ${expectedPlatforms.join(", ")}; received ${writtenPlatforms.join(", ")}.`,
+  );
+}
+process.stdout.write(`Extracted ${writtenPlatforms.length} verified image SBOMs.\n`);
+
+async function readJsonBlob(digest) {
+  const [algorithm, fingerprint] = digest.split(":");
+  if (algorithm !== "sha256" || fingerprint === undefined) {
+    throw new Error(`Unsupported OCI digest ${digest}.`);
+  }
+  const contents = await readFile(
+    path.join(layoutDirectory, "blobs", algorithm, fingerprint),
+  );
+  const actual = createHash("sha256").update(contents).digest("hex");
+  if (actual !== fingerprint) throw new Error(`OCI blob ${digest} failed verification.`);
+  return JSON.parse(contents.toString("utf8"));
+}

--- a/scripts/generate-release-sboms.sh
+++ b/scripts/generate-release-sboms.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+artifactserver_syft=${1:?Pass the Syft executable path.}
+artifactserver_input=${2:?Pass the release input directory.}
+artifactserver_output=${3:?Pass the SBOM output directory.}
+artifactserver_version=${4:?Pass the release version.}
+artifactserver_mode=${5:?Pass packages, image, or all.}
+artifactserver_stage=$(mktemp -d "${TMPDIR:-/tmp}/artifact-server-sbom.XXXXXX")
+
+cleanup() {
+  case "$artifactserver_stage" in
+    "${TMPDIR:-/tmp}"/artifact-server-sbom.*)
+      rm -rf -- "$artifactserver_stage"
+      ;;
+    *)
+      printf 'Refusing to remove unexpected SBOM staging path: %s\n' \
+        "$artifactserver_stage" >&2
+      ;;
+  esac
+}
+trap cleanup EXIT
+
+mkdir -p -- "$artifactserver_output"
+
+generate_file_sbom() {
+  local artifactserver_file=${1:?Pass an artifact file.}
+  local artifactserver_name=${2:?Pass an SBOM base name.}
+  local artifactserver_extract="$artifactserver_stage/$artifactserver_name"
+  local artifactserver_scan_root="$artifactserver_extract"
+  mkdir -p -- "$artifactserver_extract"
+  tar -xzf "$artifactserver_file" -C "$artifactserver_extract"
+  if [[ -d "$artifactserver_extract/artifactserver/node_modules" ]]; then
+    artifactserver_scan_root="$artifactserver_extract/artifactserver"
+    (
+      cd -- "$artifactserver_scan_root"
+      npm shrinkwrap --package-lock-only --ignore-scripts >/dev/null
+    )
+    mv -- \
+      "$artifactserver_scan_root/npm-shrinkwrap.json" \
+      "$artifactserver_scan_root/package-lock.json"
+  fi
+  "$artifactserver_syft" scan "dir:$artifactserver_scan_root" \
+    --source-name "$artifactserver_name" \
+    --source-version "$artifactserver_version" \
+    --output "spdx-json=$artifactserver_output/$artifactserver_name.spdx.json"
+}
+
+case "$artifactserver_mode" in
+  packages|all)
+    generate_file_sbom \
+      "$artifactserver_input/artifact-server-$artifactserver_version-node.tar.gz" \
+      "artifact-server-$artifactserver_version-node"
+    generate_file_sbom \
+      "$artifactserver_input/plannotator-artifact-server-pi-$artifactserver_version.tgz" \
+      "plannotator-artifact-server-pi-$artifactserver_version"
+    generate_file_sbom \
+      "$artifactserver_input/plannotator-artifact-server-opencode-$artifactserver_version.tgz" \
+      "plannotator-artifact-server-opencode-$artifactserver_version"
+    generate_file_sbom \
+      "$artifactserver_input/plannotator-artifact-server-claude-channel-$artifactserver_version.tgz" \
+      "plannotator-artifact-server-claude-channel-$artifactserver_version"
+    ;;
+  image)
+    ;;
+  *)
+    printf 'SBOM mode must be packages, image, or all.\n' >&2
+    exit 1
+    ;;
+esac
+
+case "$artifactserver_mode" in
+  image|all)
+    artifactserver_oci_layout="$artifactserver_stage/oci-layout"
+    mkdir -p -- "$artifactserver_oci_layout"
+    tar -xf \
+      "$artifactserver_input/artifact-server-$artifactserver_version.oci.tar" \
+      -C "$artifactserver_oci_layout"
+    node "$(dirname -- "${BASH_SOURCE[0]}")/extract-oci-sboms.mjs" \
+      "$artifactserver_oci_layout" \
+      "$artifactserver_output" \
+      "$artifactserver_version"
+    ;;
+  packages)
+    ;;
+esac

--- a/scripts/install-release-syft.sh
+++ b/scripts/install-release-syft.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+artifactserver_destination=${1:?Pass the directory where Syft should be installed.}
+artifactserver_syft_version=1.51.1
+artifactserver_system=$(uname -s)
+artifactserver_machine=$(uname -m)
+case "$artifactserver_system:$artifactserver_machine" in
+  Darwin:arm64)
+    artifactserver_syft_platform=darwin_arm64
+    artifactserver_syft_sha256=ac063af3b9874769deb7ea1e6d76841e68f9e3bb50cd654226fc977de65532c1
+    ;;
+  Darwin:x86_64)
+    artifactserver_syft_platform=darwin_amd64
+    artifactserver_syft_sha256=0e186ce1d4351ec276126851ca3ff258ed070e93e73574ed64858d4fc2339867
+    ;;
+  Linux:aarch64|Linux:arm64)
+    artifactserver_syft_platform=linux_arm64
+    artifactserver_syft_sha256=a7fd2b784e6664acd44719270574f6cd8c6864fc2b1700bf9099bd1cccda7d7f
+    ;;
+  Linux:x86_64)
+    artifactserver_syft_platform=linux_amd64
+    artifactserver_syft_sha256=8fcb33017a0dc1058298c923c436d19dfa68ae93968e0b423248542e3afb9fc3
+    ;;
+  *)
+    printf 'Syft is not pinned for %s on %s.\n' \
+      "$artifactserver_machine" "$artifactserver_system" >&2
+    exit 1
+    ;;
+esac
+artifactserver_syft_archive="syft_${artifactserver_syft_version}_${artifactserver_syft_platform}.tar.gz"
+artifactserver_stage=$(mktemp -d "${TMPDIR:-/tmp}/artifact-server-syft.XXXXXX")
+
+cleanup() {
+  case "$artifactserver_stage" in
+    "${TMPDIR:-/tmp}"/artifact-server-syft.*)
+      rm -rf -- "$artifactserver_stage"
+      ;;
+    *)
+      printf 'Refusing to remove unexpected Syft staging path: %s\n' \
+        "$artifactserver_stage" >&2
+      ;;
+  esac
+}
+trap cleanup EXIT
+
+curl --fail --location --silent --show-error \
+  "https://github.com/anchore/syft/releases/download/v${artifactserver_syft_version}/${artifactserver_syft_archive}" \
+  --output "$artifactserver_stage/$artifactserver_syft_archive"
+if command -v sha256sum >/dev/null 2>&1; then
+  artifactserver_actual_sha256=$(sha256sum \
+    "$artifactserver_stage/$artifactserver_syft_archive" | awk '{print $1}')
+else
+  artifactserver_actual_sha256=$(shasum -a 256 \
+    "$artifactserver_stage/$artifactserver_syft_archive" | awk '{print $1}')
+fi
+if [[ "$artifactserver_actual_sha256" != "$artifactserver_syft_sha256" ]]; then
+  printf 'Syft archive checksum was %s; expected %s.\n' \
+    "$artifactserver_actual_sha256" "$artifactserver_syft_sha256" >&2
+  exit 1
+fi
+
+mkdir -p -- "$artifactserver_destination"
+tar -xzf "$artifactserver_stage/$artifactserver_syft_archive" \
+  -C "$artifactserver_destination" syft
+chmod 0755 "$artifactserver_destination/syft"
+"$artifactserver_destination/syft" version


### PR DESCRIPTION
## Summary
- add a tag-gated, dry-runnable release workflow for the Node bundle, multi-architecture GHCR image, and three public adapters
- generate verified SPDX SBOMs, checksums, GitHub attestations, and a GitHub prerelease
- publish npm provenance automatically once the source repository is public; use the scoped npm token without provenance while it remains private, per npm policy
- reuse the canonical full iteration gate without dependency caches on the release path

## Verification
- `pnpm verify:iteration`
- local dry-run package, adapter, SBOM, OCI, and release-asset assembly
- shell syntax, YAML parsing, release metadata checks, `zizmor`, and `git diff --check`

The repository remains private and the root package remains unpublished, as intended.