### PR TITLE
Fix tagged release verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,6 @@ jobs:
           if [[ "$ARTIFACTSERVER_EVENT_NAME" == push && "$ARTIFACTSERVER_REF_TYPE" == tag ]]; then
             tag="$ARTIFACTSERVER_REF_NAME"
             publish=true
-            git fetch --force --no-tags origin main:refs/remotes/origin/main
             node scripts/check-release-version.mjs --tag "$tag"
             node scripts/check-release-ref.mjs --tag "$tag" --main-ref origin/main
           else


### PR DESCRIPTION
Summary: use the branch refs already fetched by checkout during tagged releases, avoiding an unauthenticated second fetch after checkout credentials are intentionally removed. Verification: the complete pnpm verify:iteration gate passed, as did local annotated v0.1.0 release-version and main-ref checks. The failed tagged run published no assets or packages, and its tag was removed before this PR.