### PR TITLE
Fix GHCR publication environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,8 +197,8 @@ jobs:
           <<< "$ARTIFACTSERVER_GITHUB_TOKEN"
       - name: Build release image
         env:
-          ARTIFACTSERVER_IMAGE_PUSH: ${{ needs.verify.outputs.publish }}
-          ARTIFACTSERVER_IMAGE_TAGS: ghcr.io/plannotator/artifact-server:${{ needs.verify.outputs.tag }},ghcr.io/plannotator/artifact-server:${{ needs.verify.outputs.series }}
+          ARTIFACT_SERVER_IMAGE_PUSH: ${{ needs.verify.outputs.publish }}
+          ARTIFACT_SERVER_IMAGE_TAGS: ghcr.io/plannotator/artifact-server:${{ needs.verify.outputs.tag }},ghcr.io/plannotator/artifact-server:${{ needs.verify.outputs.series }}
         run: pnpm package:oci release/image-work
       - name: Extract verified image SPDX SBOMs
         env:


### PR DESCRIPTION
## Summary
- pass the image-publish flag and release tags using the environment names consumed by `scripts/build-oci-image.sh`
- restore GHCR publication before digest verification in the tagged release workflow

## Verification
- `pnpm verify:iteration` (green: 298 requirements, 596 tests, all browser, storage, Compose, Helm, OIDC, performance, and packaging stages)