### PR TITLE
test: qualify Cloudflare staging media previews

### DIFF
--- a/project/evidence/cloudflare-staging-media-preview-2026-08-28.json
+++ b/project/evidence/cloudflare-staging-media-preview-2026-08-28.json
@@ -1,0 +1,69 @@
+{
+  "schemaVersion": 1,
+  "qualification": "Cloudflare staging image and video Review previews",
+  "recordedAt": "2026-08-28T17:05:21Z",
+  "result": "pass",
+  "stagingBaselineEvidence": "project/evidence/cloudflare-staging-e2e-2026-08-27.json",
+  "environment": {
+    "applicationUrl": "https://staging.artifactserver.com",
+    "contentDomain": "agentartifacts.org",
+    "accessMode": "private_team",
+    "identityProvider": "workos",
+    "records": "d1",
+    "objects": "r2",
+    "browser": "Chromium through the Codex in-app browser"
+  },
+  "fixture": {
+    "projectId": "prj_default",
+    "artifactId": "art_7c65fdcc-babf-4891-a8f2-230fdc624b14",
+    "versionId": "ver_a821b5f9-8812-4a45-84d6-762c5833603a",
+    "accessSetting": "account_required",
+    "entryPath": "preview-image.png",
+    "tags": [
+      "manual-check",
+      "media-preview"
+    ],
+    "files": [
+      {
+        "path": "preview-image.png",
+        "mediaType": "image/png",
+        "bytes": 65156
+      },
+      {
+        "path": "preview-video.webm",
+        "mediaType": "video/webm",
+        "bytes": 64232
+      }
+    ]
+  },
+  "checks": {
+    "exactReviewTarget": "pass",
+    "selectedFilePathPreservedInUrl": "pass",
+    "imageNativePreview": {
+      "result": "pass",
+      "accessibleName": "Media Preview Manual Check 2026-08-28 — preview-image.png",
+      "complete": true,
+      "naturalWidth": 1440,
+      "naturalHeight": 900,
+      "consoleErrors": 0
+    },
+    "videoNativePreview": {
+      "result": "pass",
+      "accessibleName": "Media Preview Manual Check 2026-08-28 — preview-video.webm",
+      "controls": true,
+      "autoplay": false,
+      "pausedInitially": true,
+      "readyState": 4,
+      "durationSeconds": 2,
+      "videoWidth": 640,
+      "videoHeight": 360,
+      "playbackAdvancedToSeconds": 0.714472,
+      "consoleErrors": 0
+    }
+  },
+  "notes": [
+    "The private fixture remains in the staging default project so the check can be repeated.",
+    "No product defect was observed and no deployment configuration changed."
+  ],
+  "secretsIncluded": false
+}

--- a/project/research/STAGING-E2E-REPORT-2026-08-27.md
+++ b/project/research/STAGING-E2E-REPORT-2026-08-27.md
@@ -64,6 +64,10 @@ The complete Node product path then reported the provider available, estimated o
 
 This run copied 530 fixture bytes and did not perform load or quota-pressure testing. See [`cloudflare-artifacts-live-qualification.json`](../evidence/cloudflare-artifacts-live-qualification.json).
 
+### Image and video previews follow-on
+
+On August 28, a private two-file fixture qualified the native media viewers on the same Cloudflare staging installation. Review decoded a 1440×900 PNG at its exact selected path. It also decoded a two-second 640×360 WebM, exposed native controls, started paused, and advanced during playback. Both checks completed without console errors. See [`cloudflare-staging-media-preview-2026-08-28.json`](../evidence/cloudflare-staging-media-preview-2026-08-28.json).
+
 ## What remains unqualified
 
 This pass does not prove every release claim. The following work remains separate:
@@ -71,7 +75,7 @@ This pass does not prove every release claim. The following work remains separat
 - WorkOS refresh, revocation, and named-client lifecycle behavior.
 - Cloudflare Artifacts load, quota-pressure, sustained-outage, retention, and regional behavior. The bounded normal integration is qualified; this run deliberately did not approach account limits.
 - The exact OpenCode race where its target session is deleted between claim and host admission. The live attempt delivered before deletion; the automated hostile-path proof remains green.
-- Image and video preview behavior in this run.
+- Image and video preview behavior in the August 27 run. A focused follow-on passed on August 28.
 - Manual checklist rows that were not exercised and are still blank in the product-description repository.
 
 ## Evidence posture


### PR DESCRIPTION
## Summary\n- qualify native PNG and WebM previews on the live private-team Cloudflare staging installation\n- record exact dimensions, native video controls, real playback, selected paths, and clean browser console results\n- update the staging release report with the focused follow-on\n\n## Verification\n- live WorkOS-authenticated staging Review check\n- pnpm verify:iteration\n- jq empty project/evidence/cloudflare-staging-media-preview-2026-08-28.json