### PR TITLE
docs: integrate release-ready Nimbus documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Azure teams deploy through the Helm chart on AKS; there is no separate Azure ins
 
 ## Run it locally
 
-Local mode stores metadata in SQLite and files on disk. It grants owner access only from the same loopback origin. It requires Node.js 24.12+ and pnpm 10.34.3.
+Local mode stores metadata in SQLite and files on disk. It grants owner access only from the same loopback origin. Running from source requires Node.js 24.12 or newer and pnpm 10.34.3.
 
 ```sh
 git clone https://github.com/plannotator/artifact-server.git
@@ -125,7 +125,7 @@ pnpm install
 pnpm dev
 ```
 
-Open the printed URL. Packaged installs use `artifactserver open` instead.
+Open the printed URL. Public package download and verification commands will be added on release day. See [Get started locally](https://artifactserver.com/docs/get-started/) for the current source-development path.
 
 ## Usage
 

--- a/apps/site/src/content/docs/docs/agents.mdx
+++ b/apps/site/src/content/docs/docs/agents.mdx
@@ -112,7 +112,7 @@ Pick the agent you use. The choice is remembered across pages.
           "mcpServers": {
             "artifact-server": {
               "command": "npx",
-              "args": ["-y", "@plannotator/artifact-server-claude-channel@0.1.0"]
+              "args": ["-y", "@plannotator/artifact-server-claude-channel@<release-version>"]
             }
           }
         }
@@ -133,6 +133,10 @@ Pick the agent you use. The choice is remembered across pages.
     </Steps>
 
     Without a channel, Claude Code still works at the mailbox tier through plain MCP — see the **Any MCP client** tab.
+
+    <Aside type="note" title="Before the npm release">
+      The package and release version above are placeholders. For development, use the repository launcher documented in `integrations/claude-channel/README.md`.
+    </Aside>
   </TabItem>
 
   <TabItem label="Any MCP client">

--- a/apps/site/src/content/docs/docs/concepts/security-boundary.mdx
+++ b/apps/site/src/content/docs/docs/concepts/security-boundary.mdx
@@ -23,7 +23,7 @@ app.example.com                      trusted application
 version-token.content.example.com    isolated artifact bytes
 ```
 
-The boundary lets artifacts use their own scripts, styles, images, fonts, and media without inheriting the management application's credentials or network authority.
+The boundary lets artifacts use their own scripts, styles, images, fonts, and media without inheriting the trusted Artifact Server application's credentials or network authority.
 
 <Aside type="note" title="Full screen does not remove isolation">
 Focus mode changes layout, not trust. The artifact receives more screen area while the content origin and sandbox boundary stay intact.

--- a/apps/site/src/content/docs/docs/deploy/index.mdx
+++ b/apps/site/src/content/docs/docs/deploy/index.mdx
@@ -19,7 +19,7 @@ Artifact Server runs on a laptop for one developer and deploys for a private tea
 Cloudflare is the main hosted target, and [Cloudflare Artifacts](/docs/deploy/cloudflare/) can add private Git-backed history for selected projects. Azure teams deploy through the Helm chart on AKS; there is no separate Azure installer, and Azure Blob Storage is a preview adapter that has not passed live qualification.
 
 <Aside type="note" title="Release status">
-No deployment has completed the repository's entire conformance release gate yet. Each guide names its current boundary; do not treat a target as generally available until its gate has passing evidence.
+Artifact Server has not shipped a public release. Each provider guide names the live infrastructure work already qualified. The immutable public image reference and its verification commands will be added on release day.
 </Aside>
 
 ## The boundaries every remote deployment shares

--- a/apps/site/src/content/docs/docs/get-started.mdx
+++ b/apps/site/src/content/docs/docs/get-started.mdx
@@ -3,24 +3,28 @@ title: Get started locally
 description: Run Artifact Server on a laptop and publish a first immutable artifact version.
 ---
 
-The local target runs directly on the host with SQLite, local blob storage, loopback-only content origins, and frictionless local-owner browser access. Node.js 24.12 or newer and pnpm are required when running from source.
+The local target runs directly on the host with SQLite, local blob storage, loopback-only content origins, and frictionless local-owner browser access. Running from source requires Node.js 24.12 or newer and pnpm 10.34.3.
 
-## Run from this repository
+<Aside type="note" title="Packaged release">
+The public download, checksum, and attestation commands will be added here on release day. Until then, run Artifact Server from this repository.
+</Aside>
+
+## Run from source
 
 <Steps>
   <Step title="Install dependencies">
     ```sh
+    git clone https://github.com/plannotator/artifact-server.git
+    cd artifact-server
     pnpm install
     ```
   </Step>
-  <Step title="Start the application and backend">
+  <Step title="Start Artifact Server">
     ```sh
     pnpm dev
     ```
 
-    Open the URL printed by the command. The web application normally starts at `http://127.0.0.1:5173/review`, and the development API listens at `http://127.0.0.1:8787`.
-
-    This is the source-development path. Do not run `artifactserver open` as another setup step. Contributors can run CLI commands from the checkout with `pnpm artifactserver <command>`. An installed release uses `artifactserver open` to start or find its managed local service and open Artifact Server.
+    Open the printed URL. `pnpm dev` starts both the web application and API. Do not run `artifactserver open` as a second setup step. Run CLI commands from the checkout with `pnpm artifactserver <command>`.
   </Step>
   <Step title="Publish from an agent">
     Connect the agent to the running development installation:

--- a/apps/site/src/content/docs/docs/index.mdx
+++ b/apps/site/src/content/docs/docs/index.mdx
@@ -60,7 +60,7 @@ Artifact Server installation
 One installation represents one person, team, or company. A fresh installation creates a default project. Stable artifact links resolve to the current version; exact version links never move.
 
 <Aside type="note" title="Release status">
-Artifact Server is under active development. The local application and several deployment packages exist, but no deployment has completed the repository's entire conformance release gate yet. Each deployment page names its current boundary.
+Artifact Server has not shipped a public release. Its local application, deployment packages, and private release workflow are under qualification; each deployment page names the live infrastructure boundary already proved. Public install and verification commands will be added on release day.
 </Aside>
 
 ## License

--- a/apps/site/src/content/docs/docs/security.mdx
+++ b/apps/site/src/content/docs/docs/security.mdx
@@ -88,11 +88,9 @@ A matching checksum proves that the archive matches its manifest. Until the mani
 
 ## Public release verification
 
-Artifact Server does not yet publish tagged GitHub Releases or GitHub/Sigstore attestations. There is therefore no honest `gh attestation verify` command for a public Artifact Server release today.
+Artifact Server has not shipped a tagged public release. The release workflow is qualified privately, but there is no public archive or image for an external user to verify today.
 
-The current OCI packages contain BuildKit SLSA provenance and SPDX SBOM attestations, and the repository verifies them while building. The first public release must additionally publish checksums, SBOMs, and identity-bound provenance through GitHub before this page can document public release verification.
-
-This distinction matters: a green workflow proves that the source revision passed its checks, while a public attestation must connect a downloadable asset to the repository and workflow that produced it.
+The release-day commands for downloading checksums, verifying GitHub attestations, and verifying the immutable GHCR image will be added here only after those public assets exist. Until then, the source-build evidence above is the honest verification boundary.
 
 ## Reporting and product boundaries
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,7 +2,7 @@
 
 Agents normally publish through the [Artifact Server Skill](../skills/artifact-server/SKILL.md) or [MCP](./mcp.md). Use the CLI when you want to publish directly or run operator commands from a terminal.
 
-An installed release provides the `artifactserver` command. From a source checkout, replace it with `pnpm artifactserver`.
+A packaged release will provide the `artifactserver` command. Its download, verification, and `PATH` setup commands will be added on release day. Until then, run the examples from a source checkout by replacing `artifactserver` with `pnpm artifactserver`.
 
 ## Publish an artifact
 

--- a/integrations/claude-channel/README.md
+++ b/integrations/claude-channel/README.md
@@ -41,7 +41,7 @@ flag. From a project directory:
      "mcpServers": {
        "artifact-server": {
          "command": "npx",
-         "args": ["-y", "@plannotator/artifact-server-claude-channel@0.1.0"]
+         "args": ["-y", "@plannotator/artifact-server-claude-channel@<release-version>"]
        }
      }
    }
@@ -62,7 +62,8 @@ flag. From a project directory:
    `<channel source="artifact-server">` event; Claude replies and resolves
    through `artifact_comments`, and the threads update in the web UI.
 
-For development from this repository, replace the command and arguments with
+The package version above is a release-day placeholder. For development from
+this repository, replace the command and arguments with
 `"node"` and
 `["/path/to/artifact-server/integrations/claude-channel/bin/claude-channel.js"]`.
 

--- a/project/research/RELEASE-REPORT-2026-08-27.md
+++ b/project/research/RELEASE-REPORT-2026-08-27.md
@@ -1,0 +1,72 @@
+# Artifact Server release-readiness report
+
+- Date: 2026-08-27
+- Updated: 2026-08-28
+- Qualified source revision: `8c9c54a2c55f449f67fbf5f15176397cec2fa03f`
+- Current integration base: `f172d5ef5aaa634abeaf2dfd03bfaf140159b39f`
+- Target version: `0.1.0`
+- Release status: not published
+
+## Result
+
+Artifact Server can build a portable Node archive and a multi-platform OCI image. The private release workflow has exercised packaging, checksums, SPDX SBOM generation, GitHub attestations, and clean-install verification. No public `0.1.0` release, public server package, or public adapter package has shipped.
+
+The temporary private `v0.1.0` tag was deleted after qualification. Publication-specific download URLs, image references, package names, and install commands remain release-day placeholders.
+
+## Planned release surfaces
+
+| Surface | Planned location | Status |
+| --- | --- | --- |
+| Portable Node package | `<GitHub release asset>` | Pending public release |
+| OCI image | `<public GHCR image by digest>` | Private qualification only |
+| Pi adapter | `<published Pi adapter package>` | Not published |
+| OpenCode adapter | `<published OpenCode adapter package>` | Not published |
+| Claude Code channel | `<published Claude Code channel package>` | Not published |
+
+## Verification history
+
+| Proof | Run | Result |
+| --- | --- | --- |
+| Release workflow PR simulation | [33122368219](https://github.com/plannotator/artifact-server/actions/runs/33122368219) | Pass |
+| Release workflow dry run from exact `main` | [33125545066](https://github.com/plannotator/artifact-server/actions/runs/33125545066) | Pass |
+| Clean install from dry-run assets | [33128331071](https://github.com/plannotator/artifact-server/actions/runs/33128331071) | Pass on Ubuntu and macOS; adapter package loaded |
+| First tagged attempt | [33128388757](https://github.com/plannotator/artifact-server/actions/runs/33128388757) | Failed during reference verification before publication; tag deleted |
+| Second tagged attempt | [33129865385](https://github.com/plannotator/artifact-server/actions/runs/33129865385) | Passed the canonical gate and package build, then failed before publication because the image build did not receive its push flag; tag deleted |
+| Private image-attestation qualification | Pull request 18 | Pass; GHCR remained private |
+| Public tagged release | `<release-day run>` | Not run |
+| Clean install from public assets | `<release-day run>` | Not run |
+
+The clean-install workflow uses fresh Ubuntu and macOS runners without a repository checkout. It verifies checksums and attestations, runs the packaged CLI, starts the server, publishes and fetches an artifact, and checks the URL printed by `artifactserver open`. A separate job verifies the immutable GHCR image and exercises the compact Compose profile. Another job installs an adapter package into a scratch environment and imports it.
+
+## Conformance ledger
+
+`DEP-019` covers the portable local package and remains behavior verified. `DEP-018` combines the released image with a separately packaged and signed Helm chart. The workflow verifies the chart source but does not publish a standalone chart artifact, so `DEP-018` must not be marked behavior verified. `REL-001` and `REL-002` also remain specified. This report changes no ledger status.
+
+## Release-day work
+
+- Make the repository public when the owner chooses.
+- Create the final annotated tag from the selected `main` revision.
+- Publish the portable archive, checksums, SBOMs, and attestations.
+- Publish the OCI image and record its immutable digest.
+- Publish the three adapter packages.
+- Replace documentation placeholders with the exact release URLs, package identities, and verification commands.
+- Run the clean-install workflow against the public assets.
+
+## Repository settings for publication
+
+When the owner makes the repository public, enable or confirm:
+
+- secret scanning;
+- secret-scanning push protection;
+- code scanning default setup;
+- private vulnerability reporting; and
+- recognition of the repository `SECURITY.md` policy.
+
+Also make the release image public so unauthenticated users can pull the documented digest.
+
+## Deferred
+
+- npm provenance is deferred until the repository is public.
+- The Agent Skill remains repository-native. Its public install path is finalized on release day.
+- AWS and Google Cloud live deployments were not run. Their Pulumi projects are checked in the release gate, and the shared PostgreSQL/S3-compatible runtime is exercised with pinned Postgres and MinIO.
+- Hosted-service quota and abuse-policy work is outside the core self-hosted release.


### PR DESCRIPTION
## Summary
- integrate the release-documentation work into the current Nimbus landing and documentation site
- keep public package URLs, versions, image references, and verification commands as explicit release-day placeholders
- reconcile agent setup, CLI, deployment, security, and release-readiness guidance

## Verification
- `pnpm --filter @artifact-server/site verify`
- `pnpm check`
- `pnpm verify:iteration`
- product-description link check: 630 relative links, 0 broken