### PR TITLE
docs: reconcile public guidance with qualified behavior

### DIFF
--- a/apps/site/src/content/docs/docs/agents.mdx
+++ b/apps/site/src/content/docs/docs/agents.mdx
@@ -12,7 +12,7 @@ Artifact Server closes the loop between a review and the agent that did the work
     An extension in the agent's own harness registers it with your Artifact Server and starts listening. The agent appears in the review as a presence avatar, with a ring that shows whether it is idle, thinking, or replying.
   </Step>
   <Step title="You review and send">
-    Leave comments on the version. The comment panel's main control reads **Send all open (N) to ‹agent›**. One click sends the batch; an Undo toast covers the next few seconds. Selecting a subset of comments is the secondary path.
+    Leave comments on the version. The main control reads **Send all open (N) to ‹agent›**. One click sends the batch. An Undo toast covers the next few seconds. To send less, send one comment from its card.
   </Step>
   <Step title="The agent replies and resolves">
     The bundle arrives in the agent's session as follow-up work, never as an interruption of what it is doing. The agent reads each thread, replies, and resolves the ones it addressed. Replies appear in the review as they land, attributed to the agent.

--- a/apps/site/src/content/docs/docs/connect-agents.mdx
+++ b/apps/site/src/content/docs/docs/connect-agents.mdx
@@ -16,6 +16,8 @@ Share this page and your Artifact Server address with each teammate. The address
 <Steps>
   <Step title="Open your team's Artifact Server">
     Your team lead will give you an address such as `https://artifacts.example.com`. Open it and sign in with your team account.
+
+    Open **Settings → MCP** to copy the exact address and client instructions for this installation.
   </Step>
   <Step title="Install the Agent Skill">
     Give this command to your agent, or run it in your terminal:
@@ -38,7 +40,7 @@ Share this page and your Artifact Server address with each teammate. The address
     me the full-screen review link first.
     ```
 
-    If the client needs manual MCP configuration, add the exact `/mcp` address. [See publishing and MCP details →](/docs/publish/)
+    If the client needs manual MCP settings, add the exact `/mcp` address. [Read the MCP guide →](/docs/mcp/)
   </Step>
 </Steps>
 

--- a/apps/site/src/content/docs/docs/deploy/cloudflare.mdx
+++ b/apps/site/src/content/docs/docs/deploy/cloudflare.mdx
@@ -16,9 +16,22 @@ Cloudflare is Artifact Server's first-class direct-cloud target. The deployment 
 
 ## Current release boundary
 
-<Aside type="note" title="Qualified integration; beta provider">
-Artifact Server's REST and Workers-binding paths pass the isolated live Cloudflare Artifacts qualification. Cloudflare Artifacts itself still requires beta access, and the broader Cloudflare deployment package retains its independent release gate.
+<Aside type="note" title="Live staging passed">
+The live staging pass used Artifact Server `c210384`. It covered WorkOS, D1, R2, isolated content, agent delivery, recovery, media previews, and Git history.
 </Aside>
+
+The current source revision is newer than the live staging revision. Browser and conformance verification covers the later UI and MCP-link changes. Staging did not grade those changes manually.
+
+The staging pass verified these operations:
+
+- Browser sign-in through WorkOS.
+- Publication and exact-version Review.
+- Private HTML, image, and video previews.
+- Pi, OpenCode, Claude Code, and MCP mailbox delivery.
+- Coordinated D1 and R2 recovery.
+- A bounded Cloudflare Artifacts lifecycle.
+
+The Git-history run used 530 fixture bytes. It did not apply quota pressure or load pressure.
 
 The checked-in deployment package lives in `deploy/cloudflare`. It pins Alchemy, Wrangler, Workers types, and the Cloudflare compatibility date. Team and CI deployments use Cloudflare-hosted Alchemy state.
 

--- a/apps/site/src/content/docs/docs/deploy/index.mdx
+++ b/apps/site/src/content/docs/docs/deploy/index.mdx
@@ -1,22 +1,26 @@
 ---
 title: Deploy for a team
-description: Choose a deployment target for a private team — Cloudflare, Docker Compose, Kubernetes, AWS, or Google Cloud — and the boundaries every remote installation shares.
+description: Compare the tested deployment targets and the boundaries that every remote installation uses.
 ---
 
-Artifact Server runs on a laptop for one developer and deploys for a private team on Cloudflare, one server, Kubernetes, AWS, or Google Cloud. Product behavior is the same everywhere; only the storage and infrastructure providers change.
+Artifact Server runs locally and on four server shapes. The qualification level differs by target.
 
 ## Choose a deployment
 
-| Deployment | Data layer | Guide |
-| --- | --- | --- |
-| Cloudflare | D1 and R2 | [Deploy on Cloudflare](/docs/deploy/cloudflare/) |
-| Compact Compose | SQLite and one file volume | [Compose guide](https://github.com/plannotator/artifact-server/blob/main/packaging/compose/README.md) |
-| External-storage Compose | PostgreSQL and S3-compatible storage | [Compose guide](https://github.com/plannotator/artifact-server/blob/main/packaging/compose/README.md) |
-| Kubernetes | PostgreSQL and object storage | [Helm guide](https://github.com/plannotator/artifact-server/blob/main/packaging/helm/artifact-server/README.md) |
-| AWS | ECS, RDS, and S3 | [AWS Pulumi guide](https://github.com/plannotator/artifact-server/blob/main/deploy/pulumi/aws/README.md) |
-| Google Cloud | Cloud Run, Cloud SQL, and Cloud Storage | [Google Cloud Pulumi guide](https://github.com/plannotator/artifact-server/blob/main/deploy/pulumi/gcp/README.md) |
+| Deployment | Data layer | Qualification | Guide |
+| --- | --- | --- | --- |
+| Cloudflare | D1 and R2 | Live staging passed | [Deploy on Cloudflare](/docs/deploy/cloudflare/) |
+| Compact Compose | SQLite and one file volume | Automated runtime passed | [Compose guide](https://github.com/plannotator/artifact-server/blob/main/packaging/compose/README.md) |
+| External-storage Compose | PostgreSQL and S3-compatible storage | Automated runtime passed | [Compose guide](https://github.com/plannotator/artifact-server/blob/main/packaging/compose/README.md) |
+| Kubernetes | PostgreSQL and object storage | Helm and kind verification passed | [Helm guide](https://github.com/plannotator/artifact-server/blob/main/packaging/helm/artifact-server/README.md) |
+| AWS | ECS, RDS, and S3 | Pulumi verification passed. No live application deployment. | [AWS Pulumi guide](https://github.com/plannotator/artifact-server/blob/main/deploy/pulumi/aws/README.md) |
+| Google Cloud | Cloud Run, Cloud SQL, and Cloud Storage | Pulumi verification passed. No live application deployment. | [Google Cloud Pulumi guide](https://github.com/plannotator/artifact-server/blob/main/deploy/pulumi/gcp/README.md) |
 
-Cloudflare is the main hosted target, and [Cloudflare Artifacts](/docs/deploy/cloudflare/) can add private Git-backed history for selected projects. Azure teams deploy through the Helm chart on AKS; there is no separate Azure installer, and Azure Blob Storage is a preview adapter that has not passed live qualification.
+Cloudflare is the live-qualified hosted target. [Cloudflare Artifacts](/docs/deploy/cloudflare/) can add private Git history for selected projects.
+
+AWS and Google Cloud include verified Pulumi projects. Their shared PostgreSQL and object-storage runtime passes automated verification. Neither installer completed a live application deployment.
+
+Azure teams use the Helm chart on AKS. Artifact Server has no separate Azure installer. The Azure Blob Storage adapter remains a preview.
 
 <Aside type="note" title="Release status">
 Artifact Server has not shipped a public release. Each provider guide names the live infrastructure work already qualified. The immutable public image reference and its verification commands will be added on release day.

--- a/apps/site/src/content/docs/docs/index.mdx
+++ b/apps/site/src/content/docs/docs/index.mdx
@@ -37,7 +37,7 @@ Artifact Server stores finished browser files as immutable versions and serves e
     [Connect a coding agent →](/docs/agents/)
   </Card>
   <Card title="Deploy for a team" icon="ph:cloud">
-    Choose Cloudflare, Docker Compose, Kubernetes, AWS, or Google Cloud, and set up the boundaries every remote installation shares.
+    Compare the live-qualified targets, automated deployment verification, and installer-only cloud targets.
 
     [Choose a deployment →](/docs/deploy/)
   </Card>

--- a/apps/site/src/content/docs/docs/mcp.mdx
+++ b/apps/site/src/content/docs/docs/mcp.mdx
@@ -47,6 +47,9 @@ artifactserver doctor codex
 artifactserver disconnect codex
 ```
 
+Review also provides these commands. Open **Settings → MCP** to copy the local command or the exact team-server address.
+The page links administrators to API-key settings for clients that cannot use browser authentication.
+
 ## Connect to a team server
 
 Add the exact MCP address to the client:
@@ -125,7 +128,9 @@ opens its raw immutable content. Agents should hand people the Review URL.
 | Review dispatch | `dispatch_inbox` — claim review bundles sent to this agent from the review UI |
 | Git history planning | `project_git_history_status`, `project_git_history_estimate` |
 
-Linked-artifact tools appear only when the deployment enables linked artifacts. `project_set_git_history` enables one project only after an authorized caller confirms a fresh estimate; provider configuration alone copies nothing.
+Linked-artifact tools remain in the tool list on every deployment. They return `CAPABILITY_UNAVAILABLE` when the deployment does not enable linked artifacts.
+
+`project_set_git_history` enables one project after an authorized caller confirms a fresh estimate. Provider settings alone copy nothing.
 
 ## Review feedback over MCP
 
@@ -138,6 +143,14 @@ Comments sent to an MCP-connected agent from the review UI wait in that agent's 
 ```
 
 That is the mailbox tier of the agent loop: honest, and better than pasting feedback by hand, but not a push into the running session. Pi, OpenCode, and Claude Code (through a channel) get the bundle delivered live. [Compare the tiers and connect a live agent →](/docs/agents/)
+
+## Browser agents through WebMCP
+
+Review registers seven `artifact_server_` tools when the browser provides `document.modelContext`. These tools read the selected view and manage comments with the signed-in session.
+
+Open **Settings → WebMCP** to enable or disable these tools for the current browser profile. This setting does not change external MCP clients.
+
+The browser test suite verifies registration, comment changes, and tool removal. No real WebMCP browser session completed manual qualification.
 
 ## Further reading
 

--- a/apps/site/src/content/docs/docs/security.mdx
+++ b/apps/site/src/content/docs/docs/security.mdx
@@ -7,7 +7,7 @@ Artifact Server treats workflow, dependency, package, and container integrity as
 
 <CardGrid>
   <Card title="Changes are tested" icon="ph:checks">
-    Pull requests, merge-queue candidates, and changes to `main` run the portable macOS gate and the complete Linux iteration gate.
+    Pull requests run five parallel product jobs and the macOS job. Changes to `main` run the complete Linux iteration gate.
   </Card>
   <Card title="Secrets are scanned" icon="ph:key">
     Gitleaks scans the complete Git history. Its downloaded binary is checksum-verified, and a synthetic token proves the detector before the repository scan starts.
@@ -20,11 +20,21 @@ Artifact Server treats workflow, dependency, package, and container integrity as
   </Card>
 </CardGrid>
 
-## Checks on every change
+## Pull-request verification
 
 The [CI workflow](https://github.com/plannotator/artifact-server/actions/workflows/ci.yml) runs with read-only repository permissions. Third-party actions are pinned to complete commit SHAs, checkout credentials are not persisted, and dependencies install from the committed lockfile.
 
-The macOS job runs the portable code gate. The Linux job runs `pnpm verify:iteration`, which covers linting, type checking, builds, conformance tests, browser tests, package tests, deployment checks, storage integrations, and bounded performance checks.
+The pull-request workflow runs these required jobs:
+
+- Build and static policy.
+- Unit and conformance behavior.
+- Browser behavior.
+- Cloudflare deployment behavior.
+- macOS portability.
+
+The complete Linux gate runs after a change reaches `main`. It also runs each day, during a manual full run, and before a release.
+
+The complete gate uses `pnpm verify:iteration`. It includes package, storage, Compose, Helm, OIDC, coverage, and bounded performance verification.
 
 The separate [security workflow](https://github.com/plannotator/artifact-server/actions/workflows/security.yml) runs on the same change events and every Monday:
 


### PR DESCRIPTION
## Summary

- reconcile public guidance with current Review and MCP behavior at `4daa15c`
- separate live Cloudflare evidence at `c210384` from later automated proof
- document deployment qualification without overstating AWS, GCP, or Git-history scope
- preserve release-day placeholders and private visibility

## Verification

- `pnpm verify:iteration`
- `pnpm --filter @artifact-server/site verify`
- documentation relative-link and strict style checks