### PR TITLE
chore(site): configure the public custom domain

### DIFF
--- a/apps/site/wrangler.jsonc
+++ b/apps/site/wrangler.jsonc
@@ -2,6 +2,14 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "artifact-server-site",
   "compatibility_date": "2026-08-24",
+  "workers_dev": false,
+  "preview_urls": false,
+  "routes": [
+    {
+      "pattern": "artifactserver.com",
+      "custom_domain": true
+    }
+  ],
   "assets": {
     "directory": "./dist",
     "not_found_handling": "404-page"


### PR DESCRIPTION
## Summary

- route the static public site to `artifactserver.com` as a Cloudflare Workers custom domain
- disable the incidental `workers.dev` and preview URLs
- leave the repository, packages, application, and staging deployment visibility unchanged

## Verification

- `pnpm --dir apps/site verify`
- `pnpm --dir apps/site exec wrangler deploy --dry-run`