### PR TITLE
style(site): reduce homepage hero title

### DIFF
--- a/apps/site/src/styles/landing.css
+++ b/apps/site/src/styles/landing.css
@@ -136,7 +136,7 @@
 .landing-hero h1 {
   max-width: 12ch;
   margin-top: 1.75rem;
-  font-size: clamp(3.2rem, 5.6vw, 5.6rem);
+  font-size: clamp(3rem, 5.1vw, 5.1rem);
   font-weight: 600;
   letter-spacing: -0.06em;
   line-height: 0.92;
@@ -1272,7 +1272,7 @@
   }
 
   .landing-hero h1 {
-    font-size: clamp(2.6rem, 13vw, 4rem);
+    font-size: clamp(2.4rem, 11.5vw, 3.6rem);
   }
 
   .landing-commands p {


### PR DESCRIPTION
## Summary
- reduce the homepage hero title by about 10% at desktop widths
- apply the same restrained reduction on phone widths
- preserve the three-line composition and avoid horizontal overflow

## Verification
- `pnpm --dir apps/site verify`
- desktop and iPhone visual checks
- `pnpm verify:iteration`