### PR TITLE
copy(site): mark Cloudflare artifacts closed beta

### DIFF
--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -281,7 +281,7 @@ const agents = [
             <Icon name="ph:cloud" />
             <h3>Cloudflare</h3>
             <p>The main hosted target: Workers, D1, and R2 with private team authentication and isolated content domains. Cloudflare Artifacts can add Git-backed history per project.</p>
-            <code>Workers · D1 · R2 · Artifacts (optional)</code>
+            <code>Workers · D1 · R2 · Closed beta</code>
           </article>
           <article>
             <Icon name="ph:buildings" />


### PR DESCRIPTION
## Summary
- replace the Cloudflare deployment card's `Artifacts (optional)` label with `Closed beta`
- leave the implementation detail and documentation unchanged

## Verification
- `pnpm --dir apps/site verify`
- `pnpm verify:iteration`