### PR TITLE
fix(site): correct Cloudflare Artifacts wording

### DIFF
--- a/apps/site/src/content/docs/docs/deploy/index.mdx
+++ b/apps/site/src/content/docs/docs/deploy/index.mdx
@@ -13,8 +13,8 @@ Artifact Server runs locally and on four server shapes. The qualification level 
 | Compact Compose | SQLite and one file volume | Automated runtime passed | [Compose guide](https://github.com/plannotator/artifact-server/blob/main/packaging/compose/README.md) |
 | External-storage Compose | PostgreSQL and S3-compatible storage | Automated runtime passed | [Compose guide](https://github.com/plannotator/artifact-server/blob/main/packaging/compose/README.md) |
 | Kubernetes | PostgreSQL and object storage | Helm and kind verification passed | [Helm guide](https://github.com/plannotator/artifact-server/blob/main/packaging/helm/artifact-server/README.md) |
-| AWS | ECS, RDS, and S3 | Pulumi verification passed. No live application deployment. | [AWS Pulumi guide](https://github.com/plannotator/artifact-server/blob/main/deploy/pulumi/aws/README.md) |
-| Google Cloud | Cloud Run, Cloud SQL, and Cloud Storage | Pulumi verification passed. No live application deployment. | [Google Cloud Pulumi guide](https://github.com/plannotator/artifact-server/blob/main/deploy/pulumi/gcp/README.md) |
+| AWS (Amazon Web Services) | ECS, RDS, and S3 | Pulumi verification passed. No live application deployment. | [AWS Pulumi guide](https://github.com/plannotator/artifact-server/blob/main/deploy/pulumi/aws/README.md) |
+| Google Cloud (GCP) | Cloud Run, Cloud SQL, and Cloud Storage | Pulumi verification passed. No live application deployment. | [Google Cloud Pulumi guide](https://github.com/plannotator/artifact-server/blob/main/deploy/pulumi/gcp/README.md) |
 
 Cloudflare is the live-qualified hosted target. [Cloudflare Artifacts](/docs/deploy/cloudflare/) can add private Git history for selected projects.
 

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -290,7 +290,7 @@ const agents = [
             >
               <span class="landing-cloudflare-artifacts__mark" aria-hidden="true"></span>
               <span class="landing-cloudflare-artifacts__label">
-                <small>In partnership with</small>
+                <small>Versioned and Git-backed with:</small>
                 <span>
                   <strong>Cloudflare Artifacts</strong>
                   <em>Closed beta</em>


### PR DESCRIPTION
## Summary
- remove the unsupported Cloudflare partnership claim
- describe the integration as “Versioned and Git-backed with:”
- retain the Cloudflare Artifacts link and closed-beta status
- add natural GCP and Amazon Web Services aliases to deployment docs so both terms are searchable

## Verification
- `pnpm --dir apps/site verify`
- built Pagefind index: `GCP` returns `/docs/deploy/`
- built Pagefind index: `Amazon` returns `/docs/deploy/`
- `git diff --check`